### PR TITLE
fix: added fix for remove highlight method

### DIFF
--- a/lib/assets/webpage/html/swipe.html
+++ b/lib/assets/webpage/html/swipe.html
@@ -247,7 +247,7 @@
       rendition.annotations.mark(cfiString)
     }
 
-    function removeHighLight(cfiString){
+    function removeHighlight(cfiString){
          rendition.annotations.remove(cfiString, "highlight");
     }
 


### PR DESCRIPTION
fixes #34 
swipe.html contained removeHighLight instead of removeHighlight, a small typo causing error while trying to remove highlighted text