### PR TITLE
ci: enable manual trigger for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Adds workflow_dispatch to publish.yml so it can be manually triggered from GitHub UI.